### PR TITLE
Remove exposed AWS credential file and add credential ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 .gemini/
 gha-creds-*.json
+# AWS credentials
+**/.aws*
+**/aws-keys*
+**/aws_credentials*
+**/*.pem
+**/*.key
+# GCP credentials
+**/gcp-*.json
+**/service-account*.json
+# Azure credentials
+**/azure-credentials*

--- a/cloudkeys/.aws_credentials
+++ b/cloudkeys/.aws_credentials
@@ -1,3 +1,0 @@
-[wizexchangeuser]
-aws_access_key_id = AKIA6KJQR5EGV3JVQFKU
-aws_secret_access_key = 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


### PR DESCRIPTION
### Motivation
- Remove a hardcoded AWS credential file that was present in the repository to reduce immediate exposure risk. 
- Prevent accidental future commits of cloud provider credentials by adding broad ignore patterns for common AWS, GCP, and Azure credential artifacts. 
- Note that removing the file from the working tree does not purge it from repository history, so a history rewrite is still required to fully eliminate the secret from past commits. 

### Description
- Delete the file `cloudkeys/.aws_credentials` from the repository tree. 
- Append credential ignore rules to the root `.gitignore` to cover AWS, GCP, and Azure credential filenames and key/certificate extensions. 
- Commit the changes on the current branch as a follow-up remediation PR without performing a history rewrite or key rotation. 

### Testing
- Ran `git status --short` to verify the working tree reflected the file removal and `.gitignore` update, which succeeded. 
- Ran `git log --all --full-history -- '**/.aws*' '**/*credentials*' '**/*secret*'` to search commit history for credential artifacts, and it still reports entries, indicating the secret remains in history and a repository history rewrite is required. 
- Verified the diff showing `cloudkeys/.aws_credentials` was removed and `.gitignore` was updated, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ff879566083269387f458acb35b85)